### PR TITLE
feat: add Nix flake packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,17 @@ jobs:
 
       - name: Test
         run: make test
+
+  nix-build:
+    name: Nix build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: Build
+        run: nix build .#

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ pkg/
 !.vscode/*.code-snippets
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,go
+
+# Nix / direnv
+.direnv/
+result
+
+# GoReleaser
+dist/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ brew tap corrupt952/tmuxist
 brew install tmuxist
 ```
 
+### Nix
+
+```sh
+# Run without installing (builds current main)
+nix run github:corrupt952/tmuxist -- --help
+
+# Install into your profile
+nix profile install github:corrupt952/tmuxist
+
+# Pin to a release tag or any commit (available from the tag after this feature is released)
+nix profile install github:corrupt952/tmuxist/vX.Y.Z
+```
+
 ## Commands
 
 ### tmuxist init

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "CLI tool to manage tmux sessions with configuration file";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      # Prefer the commit hash over a hand-maintained version: it can never
+      # go stale, and `nix run github:corrupt952/tmuxist` always builds main.
+      version = self.shortRev or self.dirtyShortRev or "dev";
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.buildGoModule {
+            pname = "tmuxist";
+            inherit version;
+            src = pkgs.lib.cleanSource self;
+            vendorHash = "sha256-M7nS+VeKXot/2ljQ30it2KYfwcIYmKPI13wwUWA1Omo=";
+            # Keep in sync with .goreleaser.yml.
+            ldflags = [ "-s" "-w" "-X" "tmuxist/command.Version=${version}" ];
+            meta.mainProgram = "tmuxist";
+          };
+        });
+
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.default;
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs; [
+              go
+              gopls
+              gotools
+              golangci-lint
+              goreleaser
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary
- Add a flake with a `packages` output (buildGoModule) so `nix run github:corrupt952/tmuxist` and `nix profile install github:corrupt952/tmuxist` work out of the box, plus a devShell (go/gopls/gotools/golangci-lint/goreleaser) with direnv (`.envrc`)
- Stamp the binary with the commit hash it was built from; verified the existing goreleaser ldflags path (`tmuxist/command.Version`) actually stamps, so the flake reuses it
- Add `checks` output and a CI `nix-build` job (catches vendorHash drift when Renovate bumps go.mod)
- Add a Nix section to the README installation docs (tag-pinned installs become available from the first tag cut after this lands)

## Test plan
- [x] `nix build .#` succeeds (darwin arm64) and `./result/bin/tmuxist version` prints the commit hash
- [x] `nix flake check` passes; Go tests pass inside the Nix sandbox (no `doCheck` opt-out needed)
- [x] `go test ./...` passes locally
- [ ] CI: test / lint / nix-build green

Same approach as corrupt952/xckit (on main), corrupt952/closest#611, and corrupt952/sallyport#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)